### PR TITLE
Add options to the cli helper

### DIFF
--- a/php-saas
+++ b/php-saas
@@ -9,7 +9,7 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
 
 define('PHP_SAAS_SCRIPT_ROOT', dirname(realpath(__FILE__)));
 
-$app = new Symfony\Component\Console\Application('PHP-SaaS', '0.5.0');
+$app = new Symfony\Component\Console\Application('PHP-SaaS', '0.7.0');
 $app->add(new PHPSaaS\PHPSaaS\DevCommand);
 $app->add(new PHPSaaS\PHPSaaS\NewCommand);
 

--- a/src/DevCommand.php
+++ b/src/DevCommand.php
@@ -64,6 +64,11 @@ class DevCommand extends Command
         'none',
     ];
 
+    protected array $yesNoOptions = [
+        'yes',
+        'no',
+    ];
+
     protected string $backend = 'laravel';
 
     protected string $frontend = '';
@@ -85,13 +90,13 @@ class DevCommand extends Command
         $this
             ->setName('dev')
             ->setDescription('PHPSaaS Development')
-            ->addOption('backend', null, InputArgument::OPTIONAL, 'The backend stack to use', 'laravel')
-            ->addOption('frontend', null, InputArgument::OPTIONAL, 'The frontend stack to use', '')
-            ->addOption('billing', null, InputArgument::OPTIONAL, 'The billing stack to use', '')
-            ->addOption('test', null, InputArgument::OPTIONAL, 'The testing framework to use', '')
-            ->addOption('projects', null, InputArgument::OPTIONAL, 'The projects stack to use', '')
-            ->addOption('tokens', null, InputArgument::OPTIONAL, 'Include API tokens', '')
-            ->addOption('npm', null, InputArgument::OPTIONAL, 'Run npm install after setup', '');
+            ->addOption('backend', null, InputArgument::OPTIONAL, 'The backend stack to use. Options (' . formatted_options($this->backendStacks) . ')', 'laravel')
+            ->addOption('frontend', null, InputArgument::OPTIONAL, 'The frontend stack to use. Options (' . formatted_options($this->frontendStacks) . ')', '', suggestedValues: $this->frontendStacks)
+            ->addOption('billing', null, InputArgument::OPTIONAL, 'The billing stack to use. Options (' . formatted_options($this->billingStacks) . ')', '', suggestedValues: $this->billingStacks)
+            ->addOption('test', null, InputArgument::OPTIONAL, 'The testing framework to use. Options (' . formatted_options($this->testStacks) . ')', '', suggestedValues: $this->testStacks)
+            ->addOption('projects', null, InputArgument::OPTIONAL, 'The projects stack to use. Options (' . formatted_options($this->projectsName) . ')', '', suggestedValues: $this->projectsName)
+            ->addOption('tokens', null, InputArgument::OPTIONAL, 'Include API tokens. Options (' . formatted_options($this->yesNoOptions) . ')', 'yes', suggestedValues: $this->yesNoOptions)
+            ->addOption('npm', null, InputArgument::OPTIONAL, 'Run npm install after setup. Options (' . formatted_options($this->yesNoOptions) . ')', 'no', suggestedValues: $this->yesNoOptions);
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -63,6 +63,11 @@ class NewCommand extends Command
         'none',
     ];
 
+    protected array $yesNoOptions = [
+        'yes',
+        'no',
+    ];
+
     protected string $backend = 'laravel';
 
     protected string $frontend = '';
@@ -85,13 +90,13 @@ class NewCommand extends Command
             ->setName('new')
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
-            ->addOption('backend', null, InputArgument::OPTIONAL, 'The backend stack to use', 'laravel')
-            ->addOption('frontend', null, InputArgument::OPTIONAL, 'The frontend stack to use', '')
-            ->addOption('billing', null, InputArgument::OPTIONAL, 'The billing stack to use', '')
-            ->addOption('test', null, InputArgument::OPTIONAL, 'The testing framework to use', '')
-            ->addOption('projects', null, InputArgument::OPTIONAL, 'The projects stack to use', '')
-            ->addOption('tokens', null, InputArgument::OPTIONAL, 'Include API tokens', '')
-            ->addOption('npm', null, InputArgument::OPTIONAL, 'Run npm install after setup', '');
+            ->addOption('backend', null, InputArgument::OPTIONAL, 'The backend stack to use. Options (' . formatted_options($this->backendStacks) . ')', 'laravel')
+            ->addOption('frontend', null, InputArgument::OPTIONAL, 'The frontend stack to use. Options (' . formatted_options($this->frontendStacks) . ')', '', suggestedValues: $this->frontendStacks)
+            ->addOption('billing', null, InputArgument::OPTIONAL, 'The billing stack to use. Options (' . formatted_options($this->billingStacks) . ')', '', suggestedValues: $this->billingStacks)
+            ->addOption('test', null, InputArgument::OPTIONAL, 'The testing framework to use. Options (' . formatted_options($this->testStacks) . ')', '', suggestedValues: $this->testStacks)
+            ->addOption('projects', null, InputArgument::OPTIONAL, 'The projects stack to use. Options (' . formatted_options($this->projectsName) . ')', '', suggestedValues: $this->projectsName)
+            ->addOption('tokens', null, InputArgument::OPTIONAL, 'Include API tokens. Options (' . formatted_options($this->yesNoOptions) . ')', 'yes', suggestedValues: $this->yesNoOptions)
+            ->addOption('npm', null, InputArgument::OPTIONAL, 'Run npm install after setup. Options (' . formatted_options($this->yesNoOptions) . ')', 'yes', suggestedValues: $this->yesNoOptions);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -195,3 +195,24 @@ function replace_in_file_contents(string $basePath, array $relativePaths, string
         }
     }
 }
+
+function formatted_options(array $options): string
+{
+    $green = "\033[32m";
+    $reset = "\033[0m";
+    $formatted = [];
+    foreach ($options as $key => $value) {
+        if (is_array($value)) {
+            $formatted[] = sprintf(
+                '%s%s%s',
+                $green, implode(', ', $value), $reset
+            );
+        } else {
+            $formatted[] = sprintf(
+                '%s%s%s',
+                $green, $value, $reset
+            );
+        }
+    }
+    return implode(", ", $formatted);
+}


### PR DESCRIPTION
## Description
This pull request improves the developer experience for the `dev` and `new` CLI commands by enhancing option descriptions, providing suggested values for options, and introducing a helper function for formatting option lists. It also bumps the application version to `0.7.0`.

**CLI Option Improvements:**

* Enhanced the descriptions for all options in both `DevCommand` and `NewCommand` to include the list of valid choices, using a new `formatted_options` helper function for clearer, colorized output. [[1]](diffhunk://#diff-537d56ac58859db1e396f267e9f4e1df0e4c797825636126862483466cac48d6L88-R99) [[2]](diffhunk://#diff-80009ae2f5723cd34d5f864eb4cc5e9a09425ad1ba21dca95f0e32bfb7968e83L88-R99)
* Added `suggestedValues` for options where applicable, enabling better auto-completion and validation in CLI environments. [[1]](diffhunk://#diff-537d56ac58859db1e396f267e9f4e1df0e4c797825636126862483466cac48d6L88-R99) [[2]](diffhunk://#diff-80009ae2f5723cd34d5f864eb4cc5e9a09425ad1ba21dca95f0e32bfb7968e83L88-R99)
* Introduced a reusable `yesNoOptions` array to standardize "yes/no" option handling in both commands. [[1]](diffhunk://#diff-537d56ac58859db1e396f267e9f4e1df0e4c797825636126862483466cac48d6R67-R71) [[2]](diffhunk://#diff-80009ae2f5723cd34d5f864eb4cc5e9a09425ad1ba21dca95f0e32bfb7968e83R66-R70)

**Helper Function:**

* Added a `formatted_options` function in `src/Support/helpers.php` to format and colorize option lists for CLI output.

**Version Update:**

* Updated the application version from `0.5.0` to `0.7.0` in the main script.

## Examples

**Previous command**
<img width="922" height="436" alt="image" src="https://github.com/user-attachments/assets/97bcd5da-6e48-4414-98fa-dc7a12e2fb06" />

**New Command**
<img width="906" height="427" alt="image" src="https://github.com/user-attachments/assets/0ab53d06-a3a3-4c00-97a1-9e66a400976d" />
