### PR TITLE
Prompts currently supported on Windows

### DIFF
--- a/src/Traits/CollectInputs.php
+++ b/src/Traits/CollectInputs.php
@@ -112,8 +112,7 @@ trait CollectInputs
         return select($question, $choices, default: $default, hint: $hint);
     }
 
-    private
-    function askTextWindows(string $question, $helper)
+    private function askTextWindows(string $question, $helper)
     {
         $textQuestion = new Question($question);
         return $helper->ask($this->input, $this->output, $textQuestion);

--- a/src/Traits/CollectInputs.php
+++ b/src/Traits/CollectInputs.php
@@ -2,6 +2,7 @@
 
 namespace PHPSaaS\PHPSaaS\Traits;
 
+use Symfony\Component\Console\Helper\Helper;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -88,13 +89,13 @@ trait CollectInputs
     }
 
     private function getOptionOrPrompt(
-        string $option,
-        string $question,
-        array  $choices,
-        string $default,
-        bool   $isWindows,
-               $helper,
-        string $hint = null
+        string  $option,
+        string  $question,
+        array   $choices,
+        string  $default,
+        bool    $isWindows,
+        ?Helper $helper,
+        string  $hint = null
     )
     {
         $value = $this->input->getOption($option);
@@ -105,14 +106,14 @@ trait CollectInputs
         if ($isWindows) {
             $choiceQuestion = new ChoiceQuestion($question, $choices, $default);
             $choiceQuestion->setErrorMessage("$option %s is invalid.");
-            $selected = $helper->ask($this->input, $this->output, $choiceQuestion);
-            return array_search($selected, $choices);
+            return $helper->ask($this->input, $this->output, $choiceQuestion);
         }
 
         return select($question, $choices, default: $default, hint: $hint);
     }
 
-    private function askTextWindows(string $question, $helper)
+    private
+    function askTextWindows(string $question, $helper)
     {
         $textQuestion = new Question($question);
         return $helper->ask($this->input, $this->output, $textQuestion);


### PR DESCRIPTION
## Description

This PR solve #22 issue.

This pull request refactors the `CollectInputs` trait to improve how user input is collected, especially on Windows systems. The main change is the introduction of a new helper method to streamline option selection and better handle platform-specific input differences.

Enhancements to input collection:

* Added a `getOptionOrPrompt` method to centralize logic for collecting options, supporting both interactive prompts on Unix-like systems and Symfony Console questions on Windows. This reduces code duplication and improves maintainability.
* Updated the input collection flow in `collectInputs()` to use the new helper method for all major options (`frontend`, `test`, `projects`, `billing`, `tokens`, and `npm`), ensuring consistent behavior across platforms.
* Introduced `askTextWindows` to handle free-text input on Windows using Symfony's `Question` class, improving compatibility for custom project naming.

Platform compatibility improvements:

* Added detection of Windows OS and selection of the appropriate input helper, ensuring prompts work correctly on both Windows and non-Windows systems.

Dependency updates:

* Imported `Symfony\Component\Console\Question\ChoiceQuestion` and `Question` to support the new input handling methods.

## Examples

Working on windows
<img width="757" height="485" alt="image" src="https://github.com/user-attachments/assets/ae7b59b6-3d1a-47e0-b9d3-4d9039fbbb10" />
