### PR TITLE
Update `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,4 +19,4 @@ trim_trailing_whitespace = false
 indent_size = 2
 
 [docker-compose.yml]
-i
+indent_size = 4


### PR DESCRIPTION
Update `.editorconfig` to set `indent_size` for `docker-compose.yml` to 4